### PR TITLE
Map position parameters for /imagery-search URL

### DIFF
--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -62,7 +62,7 @@ render((
       <Route path='/' component={App} auth={auth}>
         <Route path='/dashboard' component={Dashboard} onEnter={requireAuth} />
         <Route path='/about' component={About}/>
-        <Route path='/imagery-search' component={ImagerySearch} />
+        <Route path='/imagery-search(/:mapview)' component={ImagerySearch} />
         <Route path='/requests/edit' component={RequestForm} onEnter={requireRole('coordinator')} />
         <Route path='/requests/:reqid/edit' component={RequestForm} onEnter={requireRole('coordinator')} />
 


### PR DESCRIPTION
Note: the optimal event to listen for changes is `moveend` but the Mapbox
Synch plugin seems to continuously trigger it. So if the code to update
the URL is also bound to `moveend` then there is significant excess code
execution -- browser slow down and URL constantly updates. Fortunately
falling back to using a combination of `dragend` and `zoomend` seems
sufficient.

Fixes #87